### PR TITLE
Add the `c` and `e` plural operands

### DIFF
--- a/lib/cldr/export/data/plurals/rules.rb
+++ b/lib/cldr/export/data/plurals/rules.rb
@@ -161,6 +161,12 @@ module Cldr
               when 'w'
                 op = '(w = n.to_s.split(".")[1]) ? w.gsub(/0+$/, "").length : 0'
                 enclose = true
+              when 'c', 'e'
+                # We don't support numbers in the "compact decimal" format.
+                # Since `c`/`e` are always 0 for non-"compact decimal" format
+                # numbers, we just hardcode it to 0 for now.
+                op = "#{@type} = 0"
+                enclose = true
               when 'n'
                 fraction = true
                 op = 'n.to_f'

--- a/lib/cldr/export/data/plurals/rules.rb
+++ b/lib/cldr/export/data/plurals/rules.rb
@@ -60,7 +60,7 @@ module Cldr
               code = scrub_code(code)
 
               code = code.split('@').first.to_s
-              operand = /(n|i|f|t|v|w)/i
+              operand = /(c|e|n|i|f|t|v|w)/i
               expr = /#{operand}(?:\s+(?:mod|%)\s+([\d]+))?/i
               range = /(?:\d+\.\.\d+|\d+)/i
               range_list = /(#{range}(?:\s*,\s*#{range})*)/i
@@ -137,6 +137,8 @@ module Cldr
           # w       number of visible fraction digits in n, without trailing zeros.
           # f       visible fractional digits in n, with trailing zeros.
           # t       visible fractional digits in n, without trailing zeros.
+          # c       compact decimal exponent value: exponent of the power of 10 used in compact decimal formatting.
+          # e       currently, synonym for ‘c’. however, may be redefined in the future.
           #
           # http://www.unicode.org/reports/tr35/tr35-numbers.html#Language_Plural_Rules
           def to_ruby

--- a/lib/cldr/export/data/plurals/rules.rb
+++ b/lib/cldr/export/data/plurals/rules.rb
@@ -161,9 +161,11 @@ module Cldr
               when 'w'
                 op = '(w = n.to_s.split(".")[1]) ? w.gsub(/0+$/, "").length : 0'
                 enclose = true
-              else
+              when 'n'
                 fraction = true
                 op = 'n.to_f'
+              else
+                raise "unknown type '#{@type}'"
               end
               if @mod
                 op = '(' << op << ')' if enclose

--- a/test/export/data/plurals_test.rb
+++ b/test/export/data/plurals_test.rb
@@ -4,22 +4,22 @@ class TestCldrDataPluralParser < Test::Unit::TestCase
   def cldr_data
     File.read(File.dirname(__FILE__) + '/../../../vendor/cldr/common/supplemental/plurals.xml')
   end
-  
+
   def cldr_rules
     Cldr::Export::Data::Plurals::Rules.parse(cldr_data)
   end
-  
+
   def test_compiles_to_valid_ruby_code
     assert_nothing_raised { eval(cldr_rules.to_ruby) }
   end
-  
+
   def test_evals_to_a_hash_containing_plural_rule_and_keys_per_locale
     data = eval(cldr_rules.to_ruby)
     assert Hash === data
     assert Proc === data[:de][:i18n][:plural][:rule]
     assert_equal [:one, :other], data[:de][:i18n][:plural][:keys]
   end
-  
+
   def test_lookup_rule_by_locale
     assert_equal 'lambda { |n| n = n.respond_to?(:abs) ? n.abs : ((m = n.to_s)[0] == "-" ? m[1,m.length] : m); (n.to_i == 1 && ((v = n.to_s.split(".")[1]) ? v.length : 0) == 0) ? :one : :other }', cldr_rules.rule(:de).to_ruby
   end
@@ -171,6 +171,10 @@ class TestCldrDataPluralParser < Test::Unit::TestCase
     assert_equal '((n.to_f % 100) != 100 || (((n.to_f % 100) % 1).zero? && (!(10..19).include?(n.to_f % 100) || !(90..99).include?(n.to_f % 100))))', Cldr::Export::Data::Plurals::Rule.parse('n % 100 != 10..19,90..99,100').to_ruby
   end
 
+  def test_compiles_e_operand_as_always_0
+    assert_equal "((e = 0) == 0 || !(0..5).include?(e = 0))", Cldr::Export::Data::Plurals::Rule.parse('e = 0 or e != 0..5').to_ruby
+  end
+
   def test_eval_n_in
     n = 3.3
     assert_equal false, eval(Cldr::Export::Data::Plurals::Rule.parse('n mod 100 in 3..6').to_ruby, binding)
@@ -245,5 +249,18 @@ class TestCldrDataPluralParser < Test::Unit::TestCase
     assert_equal :other, fn.call(0.11)
     assert_equal :other, fn.call("0.220")
     assert_equal :other, fn.call("41.0")
+  end
+
+  def test_e_operand
+    # one: i = 0,1 @integer 0, 1 @decimal 0.0~1.5
+    # many: e = 0 and i != 0 and i % 1000000 = 0 and v = 0 or e != 0..5 @integer 1000000, 1c6, 2c6, 3c6, 4c6, 5c6, 6c6, … @decimal 1.0000001c6, 1.1c6, 2.0000001c6, 2.1c6, 3.0000001c6, 3.1c6, …
+    # other: @integer 2~17, 100, 1000, 10000, 100000, 1c3, 2c3, 3c3, 4c3, 5c3, 6c3, … @decimal 2.0~3.5, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, 1.0001c3, 1.1c3, 2.0001c3, 2.1c3, 3.0001c3, 3.1c3, …
+    fn = eval(cldr_rules.rule(:fr).to_ruby)
+    assert_equal :one, fn.call(0)
+    assert_equal :one, fn.call(1)
+    assert_equal :many, fn.call(1000000)
+    assert_equal :many, fn.call(2000000)
+    assert_equal :other, fn.call(1000001)
+    assert_equal :other, fn.call(1000000.0)
   end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes https://github.com/ruby-i18n/ruby-cldr/issues/63

Ref: http://unicode.org/reports/tr35/tr35-numbers.html#Operands

### What approach did you choose and why?

#### `#parse`

Added the operands to the regex so that the parser can understand them.

#### `#to_ruby`

`ruby-cldr` doesn't support "compact decimal" format numbers.
To do so would require refactoring the way we compute the `f`, `t`, `v`, and `w` values.

Since `c`/`e` are always 0 for non-"compact decimal" format numbers, we just hardcode it to 0 for now.

Previously, `to_ruby` assumed that any unknown operand was `n`.
I changed the `else` condition to raise, and gave `n` its own `when` case.

### What should reviewers focus on?

🤷 

### Testing

```
bundle exec thor cldr:download
bundle exec ruby test/export/data/plurals_test.rb
bundle exec thor cldr:export
```

### The impact of these changes

Users of `ruby-cldr` will be able to parse CLDR v38+ files again.