### PR TITLE
Ignore plural cases of units for now

### DIFF
--- a/lib/cldr/export/data/units.rb
+++ b/lib/cldr/export/data/units.rb
@@ -28,6 +28,7 @@ module Cldr
 
         def unit(node)
           node.xpath('unitPattern').inject({}) do |result, node|
+            next result if node.attribute('case') # Ignore cases for now. We don't have a way to expose them yet.
             count = node.attribute('count') ? node.attribute('count').value.to_sym : :one
             result[count] = node.content unless draft?(node)
             result


### PR DESCRIPTION
### What are you trying to accomplish?

Ref: https://github.com/ruby-i18n/ruby-cldr/issues/67

[This PR](https://github.com/unicode-org/cldr/pull/474) added information about cases for pluralization of units.
This code was not ready for that, and started returning whichever happened to be that last case in the section.


### What approach did you choose and why?

For now, we'll just return the case-less version as we always did.

### What should reviewers focus on?
<!--
Outline anything you'd like reviewers to pay extra attention to. List open questions for discussion.
-->

...

### The impact of these changes

We now return the same values for these strings that we did in version v37

### Testing

```
bundle exec thor cldr:download
bundle exec ruby test/export/data/units_test.rb
bundle exec thor cldr:export
```

### Checklist
- [x] This PR is safe to roll back.