### PR TITLE
Update `numbers_test` for modern CLDR

### DIFF
--- a/test/export/data/numbers_test.rb
+++ b/test/export/data/numbers_test.rb
@@ -5,6 +5,7 @@ require File.expand_path(File.join(File.dirname(__FILE__) + '/../../test_helper'
 class TestCldrDataNumbers < Test::Unit::TestCase
   test "number symbols :de" do
     expected = {
+      :approximately_sign => "≈",
       :decimal => ",",
       :exponential => "E",
       :group => ".",


### PR DESCRIPTION
### What are you trying to accomplish?

[This PR](https://github.com/unicode-org/cldr/pull/472) added the `approximately_sign` KVP.

### What approach did you choose and why?

Update the failing test to include `approximately_sign`.

### What should reviewers focus on?

I don't know of any problems the addition of `approximately_sign` could cause.

### The impact of these changes

Makes the test pass.

### Testing

```
bundle exec thor cldr:download
bundle exec ruby test/export/data/numbers_test.rb
bundle exec thor cldr:export
```

### Checklist
- [x] This PR is safe to roll back.
