### PR TITLE
Add pseudo-regions to territories test

### DIFF
--- a/test/export/data/territories_test.rb
+++ b/test/export/data/territories_test.rb
@@ -27,7 +27,8 @@ class TestCldrDataTerritories < Test::Unit::TestCase
              :SM, :SN, :SO, :SR, :SS, :ST, :SV, :SX, :SY, :SZ, :TA, :TC, :TD,
              :TF, :TG, :TH, :TJ, :TK, :TL, :TM, :TN, :TO, :TR, :TT, :TV, :TW,
              :TZ, :UA, :UG, :UN, :UM, :US, :UY, :UZ, :VA, :VC, :VE, :VG, :VI,
-             :VN, :VU, :WF, :WS, :XK, :YE, :YT, :ZA, :ZM, :ZW, :ZZ, :EZ]
+             :VN, :VU, :WF, :WS, :XA, :XB, :XK, :YE, :YT, :ZA, :ZM, :ZW, :ZZ,
+             :EZ]
 
     territories = Cldr::Export::Data::Territories.new(:de)[:territories]
     assert_empty codes - territories.keys, "Unexpected missing territories"


### PR DESCRIPTION
### What are you trying to accomplish?

This [commit](https://github.com/unicode-org/cldr/commit/d0cef5272d3a60600b487309120a7a243cb15115) added the two pseudo-regions `XA` and `XB`.

### What approach did you choose and why?

Update the test to recognize this change.

### What should reviewers focus on?

Some consumers of `ruby-cldr` data might expect the list of territories not to contain the pseudo-regions.
However, they already have to deal with the `ZZ` ("Unknown Region") region, so their code would already be incorrect.

Besides, `ruby-cldr`'s job is to faithfully expose the CLDR data, but in a Ruby-friendly way, not necessarily in a way that is directly useful to end consumers. So we shouldn't contemplate not exposing these regions.

### The impact of these changes

The territory tests will pass for modern CLDR

### Testing

```
bundle exec thor cldr:download
bundle exec ruby test/export/data/territories_test.rb
bundle exec thor cldr:export
```

### Checklist
- [x] This PR is safe to roll back.
