### PR TITLE
Hyphenate the locales in `parent_locales.yml`

### DIFF
--- a/lib/cldr/export.rb
+++ b/lib/cldr/export.rb
@@ -132,15 +132,15 @@ module Cldr
       end
 
       def locales(locale, component, options)
-        locale = to_i18n(locale)
+        locale = to_i18n(locale).to_s
 
         locales = if options[:merge]
           defined_parents = Cldr::Export::Data::ParentLocales.new
 
           ancestry = [locale]
           loop do
-            if defined_parents[from_i18n(ancestry.last)]
-              ancestry << to_i18n(defined_parents[from_i18n(ancestry.last)])
+            if defined_parents[ancestry.last]
+              ancestry << defined_parents[ancestry.last]
             elsif I18n::Locale::Tag.tag(ancestry.last).self_and_parents.count > 1
               ancestry << I18n::Locale::Tag.tag(ancestry.last).self_and_parents.last.to_sym
             else

--- a/lib/cldr/export/data/base.rb
+++ b/lib/cldr/export/data/base.rb
@@ -11,7 +11,7 @@ module Cldr
         def initialize(locale)
           @locale = locale
         end
-      
+
         def update(hash)
           hash.each { |key, value| self[key] = value }
         end
@@ -46,7 +46,7 @@ module Cldr
           def select(*sources)
             doc.xpath(xpath(sources))
           end
-        
+
           def xpath(sources)
             path = sources.map { |source| source.respond_to?(:path) ? source.path : source }.join('/')
             path =~ /^\/?\/ldml/ ? path : "//ldml/#{path}"
@@ -57,7 +57,7 @@ module Cldr
           end
 
           def path
-            @path ||= "#{Cldr::Export::Data.dir}/main/#{locale.to_s.gsub('-', '_')}.xml"
+            @path ||= "#{Cldr::Export::Data.dir}/main/#{Cldr::Export.from_i18n(locale)}.xml"
           end
       end
     end

--- a/lib/cldr/export/data/languages.rb
+++ b/lib/cldr/export/data/languages.rb
@@ -9,7 +9,7 @@ module Cldr
 
         def languages
           @languages ||= select('localeDisplayNames/languages/language').inject({}) do |result, node|
-            result[node.attribute('type').value.gsub('_', '-').to_sym] = node.content unless draft?(node) or alt?(node)
+            result[Cldr::Export.to_i18n(node.attribute('type').value)] = node.content unless draft?(node) or alt?(node)
             result
           end
         end

--- a/lib/cldr/export/data/parent_locales.rb
+++ b/lib/cldr/export/data/parent_locales.rb
@@ -9,8 +9,8 @@ module Cldr
           doc = File.open(path) { |file| Nokogiri::XML(file) }
 
           doc.xpath('//parentLocales/parentLocale').each do |node|
-            parent = node.attr('parent')
-            locales = node.attr('locales').split(' ')
+            parent = Cldr::Export.to_i18n(node.attr('parent')).to_s
+            locales = node.attr('locales').split(' ').map {|locale| Cldr::Export.to_i18n(locale) }.map(&:to_s)
 
             locales.each do |locale|
               self[locale] = parent

--- a/lib/cldr/export/data/plurals/rules.rb
+++ b/lib/cldr/export/data/plurals/rules.rb
@@ -94,7 +94,7 @@ module Cldr
           attr_reader :locales
 
           def initialize(locales)
-            @locales = locales.map { |locale| locale.gsub('_', '-').to_sym }
+            @locales = locales.map { |locale| Cldr::Export.to_i18n(locale) }
           end
 
           def keys

--- a/lib/cldr/export/data/rbnf.rb
+++ b/lib/cldr/export/data/rbnf.rb
@@ -63,7 +63,7 @@ module Cldr
         end
 
         def path
-          @path ||= "#{Cldr::Export::Data.dir}/rbnf/#{locale.to_s.gsub('-', '_')}.xml"
+          @path ||= "#{Cldr::Export::Data.dir}/rbnf/#{Cldr::Export.from_i18n(locale)}.xml"
         end
 
       end

--- a/lib/cldr/export/data/subdivisions.rb
+++ b/lib/cldr/export/data/subdivisions.rb
@@ -26,7 +26,7 @@ module Cldr
         end
 
         def path
-          @path ||= "#{Cldr::Export::Data.dir}/subdivisions/#{locale.to_s.gsub('-', '_')}.xml"
+          @path ||= "#{Cldr::Export::Data.dir}/subdivisions/#{Cldr::Export.from_i18n(locale)}.xml"
         end
 
       end

--- a/lib/cldr/export/yaml.rb
+++ b/lib/cldr/export/yaml.rb
@@ -10,7 +10,7 @@ module Cldr
         unless data.empty?
           data = data.deep_stringify_keys if data.respond_to?(:deep_stringify_keys)
           data = data.deep_sort if data.respond_to?(:deep_sort)
-          data = { locale.to_s.gsub('_', '-') => data } if locale != ""
+          data = { Cldr::Export.to_i18n(locale).to_s => data } if locale != ""
           path = Export.path(locale, component, 'yml')
           Export.write(path, yaml(data))
           yield(component, locale, path) if block_given?


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes https://github.com/ruby-i18n/ruby-cldr/issues/92, building off of https://github.com/ruby-i18n/ruby-cldr/issues/91

### What approach did you choose and why?

We already have locale conversion helpers in `Cldr::Export`.

* I changed `ParentLocales` to use that
  * I maintained the signature of `Map<String, String>`
    * If I had changed it to `Map<Symbol, Symbol>`, it would have changed the exported file since `YAML.dump` serializes `Symbol`s differently than `String` values)
* I removed unnecessary conversion in `Cldr::Export#locales`
* I then did a find/replace for other places in the code that were doing these same conversions 

I verified that these changes only changed `parent_locales.yml` by exporting both sets of data and diffing them.

```bash
git checkout movermeyer:mo.output_parent_locales_once
thor cldr:export --target=./data_from_parent_pr

git checkout movermeyer:mo.hyphenate_parent_locale
thor cldr:export --target=./data_from_this_pr

diff -r data_from_parent_pr data_from_this_pr
```

I also did the same with the `--merge` flag set

### What should reviewers focus on?

🤷 

### The impact of these changes

Consistent locale formatting throughout `ruby-cldr`

### Testing / 🎩

```bash
thor cldr:export --components=parentLocales
```

Then look at `data/parent_locales.yml` and notice that all the locales are their hyphenated versions.